### PR TITLE
docs: add execute_update examples for rust, go, python

### DIFF
--- a/go/client.go
+++ b/go/client.go
@@ -102,6 +102,16 @@ func (client *Client) Execute(sql string) ([]arrow.Record, error) {
 	return client.doGet(flightInfo.GetEndpoint()[0].GetTicket())
 }
 
+// Executes the sql on Datalayers and returns the affected rows.
+// The supported sqls are Insert and Delete. Note, the development for supporting Delete is in progress.
+func (client *Client) ExecuteUpdate(sql string) (int64, error) {
+	affectedRows, err := client.inner.ExecuteUpdate(client.ctx, sql)
+	if err != nil {
+		return 0, fmt.Errorf("failed to execute a sql: %v", err)
+	}
+	return affectedRows, nil
+}
+
 // Creates a prepared statement.
 func (client *Client) Prepare(sql string) (*flightsql.PreparedStatement, error) {
 	return client.inner.Prepare(client.ctx, sql)
@@ -117,6 +127,11 @@ func (client *Client) ExecutePrepared(preparedStmt *flightsql.PreparedStatement,
 		return nil, fmt.Errorf("failed to execute a prepared statement: %v", err)
 	}
 	return client.doGet(flightInfo.GetEndpoint()[0].GetTicket())
+}
+
+// Closes the prepared statement.
+func (client *Client) ClosePrepared(preparedStmt *flightsql.PreparedStatement) error {
+	return preparedStmt.Close(client.ctx)
 }
 
 // Calls the `DoGet` method of the FlightSQL client.

--- a/go/main.go
+++ b/go/main.go
@@ -162,14 +162,17 @@ func main() {
         INSERT INTO go.demo (ts, sid, value, flag) VALUES
             ('2024-09-03T10:00:00+08:00', 1, 4.5, 0),
             ('2024-09-03T10:05:00+08:00', 2, 11.6, 1);`
-	affectedRows, err := client.ExecuteUpdate(sql)
+	_, err = client.ExecuteUpdate(sql)
 	if err != nil {
 		fmt.Println("Failed to insert data: ", err)
 		return
 	}
+	// It's expected that the affected rows is 2.
+	// However, the Go implementation of Arrow Flight SQL client might have some flaws and the affected rows is always 0.
+	//
 	// The output should be:
 	// Affected rows: 2
-	fmt.Println("Affected rows: ", affectedRows)
+	// fmt.Println("Affected rows: ", affectedRows)
 
 	// Checks that the data are inserted successfully.
 	sql = "SELECT * FROM go.demo where ts >= '2024-09-03T10:00:00+08:00'"

--- a/go/main.go
+++ b/go/main.go
@@ -162,17 +162,14 @@ func main() {
         INSERT INTO go.demo (ts, sid, value, flag) VALUES
             ('2024-09-03T10:00:00+08:00', 1, 4.5, 0),
             ('2024-09-03T10:05:00+08:00', 2, 11.6, 1);`
-	_, err = client.ExecuteUpdate(sql)
+	affectedRows, err := client.ExecuteUpdate(sql)
 	if err != nil {
 		fmt.Println("Failed to insert data: ", err)
 		return
 	}
-	// It's expected that the affected rows is 2.
-	// However, the Go implementation of Arrow Flight SQL client might have some flaws and the affected rows is always 0.
-	//
 	// The output should be:
 	// Affected rows: 2
-	// fmt.Println("Affected rows: ", affectedRows)
+	fmt.Println("Affected rows: ", affectedRows)
 
 	// Checks that the data are inserted successfully.
 	sql = "SELECT * FROM go.demo where ts >= '2024-09-03T10:00:00+08:00'"

--- a/go/main.go
+++ b/go/main.go
@@ -147,4 +147,40 @@ func main() {
 	//    2024-09-01 10:05:00 +0800 CST     2   15.30      1
 	//    2024-09-02 10:05:00 +0800 CST     2   15.30      1
 	PrintRecords(result)
+
+	// Closes the prepared statement to notify releasing resources on server side.
+	if err = client.ClosePrepared(preparedStmt); err != nil {
+		fmt.Println("Failed to close a prepared statement: ", err)
+		return
+	}
+
+	// There provides a dedicated interface `execute_update` for executing DMLs, including Insert, Delete.
+	// This interface directly returns the affected rows which might be convenient for some use cases.
+	//
+	// Note, Datalayers does not support Update and the development for Delete is in progress.
+	sql = `
+        INSERT INTO go.demo (ts, sid, value, flag) VALUES
+            ('2024-09-03T10:00:00+08:00', 1, 4.5, 0),
+            ('2024-09-03T10:05:00+08:00', 2, 11.6, 1);`
+	affectedRows, err := client.ExecuteUpdate(sql)
+	if err != nil {
+		fmt.Println("Failed to insert data: ", err)
+		return
+	}
+	// The output should be:
+	// Affected rows: 2
+	fmt.Println("Affected rows: ", affectedRows)
+
+	// Checks that the data are inserted successfully.
+	sql = "SELECT * FROM go.demo where ts >= '2024-09-03T10:00:00+08:00'"
+	result, err = client.Execute(sql)
+	if err != nil {
+		fmt.Println("Failed to scan data: ", err)
+		return
+	}
+	// The result should be:
+	// 	                              ts   sid   value   flag
+	//    2024-09-03 10:00:00 +0800 CST     1    4.50      0
+	//    2024-09-03 10:05:00 +0800 CST     2   11.60      1
+	PrintRecords(result)
 }

--- a/python/client.py
+++ b/python/client.py
@@ -102,6 +102,15 @@ class Client:
         df = reader.read_pandas()
         return df
 
+    def execute_update(self, sql: str) -> int:
+        """
+        Executes the sql on Datalayers and returns the affected rows.
+        This method is meant to be used for executing DMLs, including Insert and Delete.
+        Note, Datalayers does not support Update and the development of Delete is in progress.
+        """
+
+        return self.inner.execute_update(sql, None)
+
     def prepare(self, sql: str) -> PreparedStatement:
         """
         Creates a prepared statement.
@@ -121,6 +130,15 @@ class Client:
         reader = self.inner.do_get(ticket)
         df = reader.read_pandas()
         return df
+
+    def close_prepared(self, prepared_stmt: PreparedStatement):
+        """
+        Closes the prepared statement.
+        Note, generally you should not call this method explicitly.
+        Use with clause to manage the life cycle of a prepared statement instead.
+        """
+
+        prepared_stmt.close()
 
     def close(self):
         """

--- a/python/main.py
+++ b/python/main.py
@@ -114,13 +114,10 @@ def main():
             ('2024-09-03T10:00:00+08:00', 1, 4.5, 0),
             ('2024-09-03T10:05:00+08:00', 2, 11.6, 1);
         """
-    #! It's expected that the affected rows is 2.
-    #! However, the flightsql-dbapi library seems does not implement the `execute_update` correctly
-    #! and the returned affected rows is always 0.
     affected_rows = client.execute_update(sql)
     # The output should be:
     # Affected rows: 2
-    # print("Affected rows: {}".format(affected_rows))
+    print("Affected rows: {}".format(affected_rows))
 
     # Checks that the data are inserted successfully.
     sql = "SELECT * FROM python.demo where ts >= '2024-09-03T10:00:00+08:00'"

--- a/python/main.py
+++ b/python/main.py
@@ -115,7 +115,7 @@ def main():
             ('2024-09-03T10:05:00+08:00', 2, 11.6, 1);
         """
     #! It's expected that the affected rows is 2.
-    #! However, the flightsql-dbapi library does not implement the `execute_update` correctly
+    #! However, the flightsql-dbapi library seems does not implement the `execute_update` correctly
     #! and the returned affected rows is always 0.
     affected_rows = client.execute_update(sql)
     # The output should be:

--- a/python/main.py
+++ b/python/main.py
@@ -105,6 +105,32 @@ def main():
         # 1 2024-09-02 10:05:00+08:00    2   15.3     1
         print(result)
 
+    # There provides a dedicated interface `execute_update` for executing DMLs, including Insert, Delete.
+    # This interface directly returns the affected rows which might be convenient for some use cases.
+    #
+    # Note, Datalayers does not support Update and the development for Delete is in progress.
+    sql = """
+        INSERT INTO python.demo (ts, sid, value, flag) VALUES
+            ('2024-09-03T10:00:00+08:00', 1, 4.5, 0),
+            ('2024-09-03T10:05:00+08:00', 2, 11.6, 1);
+        """
+    #! It's expected that the affected rows is 2.
+    #! However, the flightsql-dbapi library does not implement the `execute_update` correctly
+    #! and the returned affected rows is always 0.
+    affected_rows = client.execute_update(sql)
+    # The output should be:
+    # Affected rows: 2
+    # print("Affected rows: {}".format(affected_rows))
+
+    # Checks that the data are inserted successfully.
+    sql = "SELECT * FROM python.demo where ts >= '2024-09-03T10:00:00+08:00'"
+    result = client.execute(sql)
+    # The result should be:
+    #                          ts  sid  value  flag
+    # 0 2024-09-03 10:00:00+08:00    1    4.5     0
+    # 1 2024-09-03 10:05:00+08:00    2   11.6     1
+    print(result)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
给 rust、go、python 添加关于 execute_update 的 demo 代码。尚未给 java example 添加 execute_update 的 demo。

特别注意：rust 的 arrow flight sql 客户端能够使用 execute update 正确获取服务端返回的 affected rows。但是 go 和 python 的客户端却不行，它们总是返回 affected rows = 0，因为这是默认的值。经过一番研究代码以后，还是没找到问题所在。后续会跟进这个问题。